### PR TITLE
Exclude ember-statecharts from auto-import

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@
 module.exports = {
   name: require('./package').name,
 
+  options: {
+    autoImport: {
+      exclude: ['ember-statecharts']
+    }
+  },
+
   included() {
     this._super.included.apply(this, arguments);
 


### PR DESCRIPTION
This will throw an error and we don't need
to include ember-statechart dependencies as
we bundle xstate ourselves.